### PR TITLE
csvlint now uses objects not hashes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/theodi/csvlint.rb.git
-  revision: d6b5b4aaa50e204a781e557fa4b0e6f08b66e1fa
+  revision: 1deedcfe58ac88cfe8ad15a9891d92db56b4307b
   specs:
     csvlint (0.0.1)
       mime-types

--- a/app/views/validation/_message.html.erb
+++ b/app/views/validation/_message.html.erb
@@ -1,7 +1,7 @@
-<%= t(message[:type]).capitalize %>
-<% if message[:row] %>
-  on row <%= message[:row] %>
+<%= t(message.type).capitalize %>
+<% if message.row %>
+  on row <%= message.row %>
 <% end %>
-<% if message[:content] %>
-  <%= content_tag :pre, message[:content] %>
+<% if message.content %>
+  <%= content_tag :pre, message.content %>
 <% end %>


### PR DESCRIPTION
Fixes template to call methods on ErrorMessage not use keys in hash.
