### PR TITLE
Fix erroneous Slimmer downgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,6 @@ end
 
 gem 'rack-google-analytics'
 gem 'plek'
-gem 'slimmer'
+gem 'slimmer', '~> 3.25.0'
 
 gem 'csvlint', github: 'theodi/csvlint.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    PriorityQueue (0.1.2)
     actionmailer (4.0.2)
       actionpack (= 4.0.2)
       mail (~> 2.5.4)
@@ -141,13 +142,14 @@ GEM
       celluloid-io (>= 0.15.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
+    lrucache (0.1.4)
+      PriorityQueue (~> 0.1.2)
     lumberjack (1.0.4)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_portile (0.5.2)
     minitest (4.7.5)
     multi_json (1.8.4)
     multi_test (0.0.3)
@@ -156,8 +158,8 @@ GEM
     net-http-persistent (2.9.4)
     net-http-pipeline (1.0.1)
     nio4r (1.0.0)
-    nokogiri (1.6.1)
-      mini_portile (~> 0.5.0)
+    nokogiri (1.5.11)
+    null_logger (0.0.1)
     plek (1.7.0)
     polyglot (0.3.3)
     pry (0.9.12.6)
@@ -224,8 +226,14 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
-    slimmer (0.8.0)
-      nokogiri
+    slimmer (3.25.0)
+      json
+      lrucache (~> 0.1.3)
+      nokogiri (~> 1.5.0)
+      null_logger
+      plek (>= 0.1.8)
+      rack (>= 1.3.5)
+      rest-client
     slop (3.4.7)
     sprockets (2.10.1)
       hike (~> 1.2)
@@ -304,7 +312,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 4.0.0)
   sdoc
-  slimmer
+  slimmer (~> 3.25.0)
   sqlite3
   therubyracer
   thin


### PR DESCRIPTION
Somewhere along the line (bad manual merge possibly), we managed to downgrade Slimmer back to 0.8.0, so the template wasn't getting loaded in. All fixed now!
