### PR TITLE
When displaying content, force it to output as UTF8, with replacement chars

### DIFF
--- a/app/views/validation/_message.html.erb
+++ b/app/views/validation/_message.html.erb
@@ -6,7 +6,7 @@
   in column <%= message.column %>
 <% end %></strong></p>
 <% if message.content %>
-  <%= content_tag :pre, message.content %>
+  	<%= content_tag :pre, message.content.to_s.encode("utf-8", :invalid=>:replace, :undef=>:replace) %>
 <% end %>
 <% if i18n_set?("#{message.type}_guidance_html") %>
   <p><%= t("#{message.type}_guidance_html", message_variables(validator, message) ) %></p>


### PR DESCRIPTION
This fixes #74.

Forces content into a UTF-8. However I can't find a way to do this only when needed. I suspect the encoding adds some overhead.
