### PR TITLE
Allow API access to validation creation

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,11 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  # Prevent CSRF attacks by using a null session
+  protect_from_forgery with: :null_session
 
   def standard_csv_options
     {row_sep: "\r\n", encoding: "UTF-8", force_quotes: true}
   end
-  
+
   def index
     if params[:uri]
       validator = Validation.where(:url => params[:uri]).first
@@ -17,5 +16,5 @@ class ApplicationController < ActionController::Base
 
   def about
   end
-  
+
 end

--- a/features/api.feature
+++ b/features/api.feature
@@ -6,6 +6,17 @@ Feature: CSVlint API
     Given the fixture "csvs/warnings.csv" is available at the URL "http://example.org/warnings.csv"
     Given the fixture "csvs/info.csv" is available at the URL "http://example.org/info.csv"
 
+  Scenario: API access to create validations
+    When I send and accept JSON
+    And I send a POST request to "/package" with the following:
+    """
+    {"urls":["http://example.org/test.csv"]}
+    """
+    Then the response status should be "302"
+    When I visit the new location
+    And the JSON response should have "$..version" with the text "0.1"
+    And the JSON response should have "$..validation..state" with the text "valid"
+
   Scenario: View valid validation as JSON
     Given I have already validated the URL "http://example.org/test.csv"
     When I send and accept JSON

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -1,3 +1,8 @@
+When(/^I visit the new location$/) do
+  location = last_response.headers["Location"].split("example.org")[1]
+  step "I send a GET request to \"#{location}\""
+end
+
 When(/^I send a GET request to view the validation$/) do
   steps %Q{
     And I send a GET request to "/validation/#{@validation.id}"


### PR DESCRIPTION
Not perfect - should be a 201 instead of 302, but this accepts a JSON list of URLs and gives you back validations.
