### PR TITLE
Fix URIs in documentation

### DIFF
--- a/app/views/application/about.html.erb
+++ b/app/views/application/about.html.erb
@@ -295,21 +295,21 @@
 <p>The supported data types are currently:</p>
 
 <ul>
-  <li>string &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#string"><code>http://www.w3.org/TR/xmlschema-2/#string</code></a>
-  <li>integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#int"><code>http://www.w3.org/TR/xmlschema-2/#int</code></a>
-  <li>float &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#float"><code>http://www.w3.org/TR/xmlschema-2/#float</code></a>
-  <li>double &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#double"><code>http://www.w3.org/TR/xmlschema-2/#double</code></a>
-  <li>URL &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#anyURI"><code>http://www.w3.org/TR/xmlschema-2/#anyURI</code></a>
-  <li>boolean &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#boolean"><code>http://www.w3.org/TR/xmlschema-2/#boolean</code></a>
-  <li>non-positive integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#nonPositiveInteger"><code>http://www.w3.org/TR/xmlschema-2/#nonPositiveInteger</code></a>
-  <li>positive integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#positiveInteger"><code>http://www.w3.org/TR/xmlschema-2/#positiveInteger</code></a>
-  <li>non-negative integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger"><code>http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger</code></a>
-  <li>negative integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#negativeInteger"><code>http://www.w3.org/TR/xmlschema-2/#negativeInteger</code></a>
-  <li>date &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#date"><code>http://www.w3.org/TR/xmlschema-2/#date</code></a>
-  <li>date &amp; time &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#dateTime"><code>http://www.w3.org/TR/xmlschema-2/#dateTime</code></a>
-  <li>year &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#gYear"><code>http://www.w3.org/TR/xmlschema-2/#gYear</code></a>
-  <li>year &amp; month &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#gYearMonth"><code>http://www.w3.org/TR/xmlschema-2/#gYearMonth</code></a>
-  <li>time &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#time"><code>http://www.w3.org/TR/xmlschema-2/#time</code></a>
+  <li>string &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#string"><code>http://www.w3.org/2001/XMLSchema#string</code></a>
+  <li>integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#int"><code>http://www.w3.org/2001/XMLSchema#int</code></a>
+  <li>float &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#float"><code>http://www.w3.org/2001/XMLSchema#float</code></a>
+  <li>double &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#double"><code>http://www.w3.org/2001/XMLSchema#double</code></a>
+  <li>URL &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#anyURI"><code>http://www.w3.org/2001/XMLSchema#anyURI</code></a>
+  <li>boolean &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#boolean"><code>http://www.w3.org/2001/XMLSchema#boolean</code></a>
+  <li>non-positive integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#nonPositiveInteger"><code>http://www.w3.org/2001/XMLSchema#nonPositiveInteger</code></a>
+  <li>positive integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#positiveInteger"><code>http://www.w3.org/2001/XMLSchema#positiveInteger</code></a>
+  <li>non-negative integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#nonNegativeInteger"><code>http://www.w3.org/2001/XMLSchema#nonNegativeInteger</code></a>
+  <li>negative integer &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#negativeInteger"><code>http://www.w3.org/2001/XMLSchema#negativeInteger</code></a>
+  <li>date &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#date"><code>http://www.w3.org/2001/XMLSchema#date</code></a>
+  <li>date &amp; time &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#dateTime"><code>http://www.w3.org/2001/XMLSchema#dateTime</code></a>
+  <li>year &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#gYear"><code>http://www.w3.org/2001/XMLSchema#gYear</code></a>
+  <li>year &amp; month &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#gYearMonth"><code>http://www.w3.org/2001/XMLSchema#gYearMonth</code></a>
+  <li>time &mdash; <a href="http://www.w3.org/TR/xmlschema-2/#time"><code>http://www.w3.org/2001/XMLSchema#time</code></a>
 </ul>
 
 <p>Use of an unknown data type will result in the column failing to validate.</p>


### PR DESCRIPTION
Fix the URIs in the documentation to use the actual namespace URIs (but retaining links to the docs).
