### PR TITLE
Show SVG images on /validations

### DIFF
--- a/app/views/validation/_validation.html.erb
+++ b/app/views/validation/_validation.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= image_tag validation_url(validation, format: :png, revalidate: false) %></td>
+  <td><%= image_tag validation_url(validation, format: :svg, revalidate: false) %></td>
   <td class="url"><%= validation.url.blank? ? validation.filename : validation.url %></td>
   <td class="text-right"><%= link_to "<i class='glyphicon glyphicon-list-alt'></i> View report".html_safe, validation_url(validation), title: "View report for #{validation.url}" %></td>
   <td class="text-right"><%= link_to "<i class='glyphicon glyphicon-cloud-download'></i> Download CSV".html_safe, validation.url, title: "Download CSV for #{validation.url}" %></td>


### PR DESCRIPTION
I was just surfing csvlint.io thanks to @floppy and noticed that csvlint.io/validations uses PNG whereas a validation's `show` page uses the SVG. I figured SVG would be a better way to go (better for retina screens and still fine for regular screens).

Great work on this service!
