### PR TITLE
Fix typos

### DIFF
--- a/app/views/application/about.html.erb
+++ b/app/views/application/about.html.erb
@@ -59,7 +59,7 @@
 
 <p>If your CSV File is sizeable and contains only one row, CSVLint detects that
   your file may be using a different "dialect". For example, your file may use
-<code>;</code> delimiters to seperate fields rather than the standard
+<code>;</code> delimiters to separate fields rather than the standard
 <code>,</code>. Although it is encouraged to keep to CSV Standard File
 Format, we provide an option to change the dialect to suit your particular file.</p>
 

--- a/app/views/application/documentation.html.erb
+++ b/app/views/application/documentation.html.erb
@@ -13,7 +13,7 @@
 <pre><code>curl -L --data "urls[]=http://theodi.github.io/hot-drinks/hot-drinks.csv" http://csvlint.io/package.json
 </code></pre>
 
-<p>(<code>urls[]</code> can also be a comma seperated list of urls) </p>
+<p>(<code>urls[]</code> can also be a comma separated list of urls) </p>
 
 <p>Or with a schema:</p>
 


### PR DESCRIPTION
Correct spelling of `separate`
